### PR TITLE
Add Netlify configuration for production build and redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "ng build --configuration production"
+  publish = "dist/country-app/browser"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Introduce a `netlify.toml` file to define the build command and set up redirects for the application.